### PR TITLE
Configure m4ri with SSE2 toggle

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,16 @@
-cd solvers/kissat-inc;
-./configure && make -j;
-cd ..;
-cd ..;
-make clean; make -j;
+ARCH="$(uname -m)"
+
+cd solvers/kissat-inc
+./configure && make -j
+cd ../..
+
+cd preprocess/m4ri-20140914
+if echo "$ARCH" | grep -qE "x86|amd64"; then
+  ./configure && make -j
+else
+  ./configure --disable-sse2 && make -j
+fi
+cd ../..
+
+make clean
+make -j

--- a/docker/common/Dockerfile
+++ b/docker/common/Dockerfile
@@ -12,13 +12,16 @@ COPY / /PRS
 
 WORKDIR /PRS/solvers/kissat-inc
 RUN make clean
-RUN ./configure
-RUN make -j
+RUN ./configure && make -j
 
 WORKDIR /PRS/preprocess/m4ri-20140914
 RUN make clean
-RUN ./configure
-RUN make -j
+RUN ARCH="$(uname -m)" && \
+    if echo "$ARCH" | grep -qE "x86|amd64"; then \
+        ./configure && make -j; \
+    else \
+        ./configure --disable-sse2 && make -j; \
+    fi
 
 WORKDIR /PRS
 RUN make clean


### PR DESCRIPTION
## Summary
- disable SSE2 only for m4ri when the architecture isn't x86 or amd64
- keep kissat build unchanged in both build.sh and Dockerfile