### PR TITLE
Fix memory deallocation in Bitset

### DIFF
--- a/utils/bitset.cpp
+++ b/utils/bitset.cpp
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <cstdlib>
 #include "bitset.hpp"
 
 std::random_device rd;
@@ -33,7 +34,7 @@ void Bitset::hash() noexcept{
 }
 
 void Bitset::free() noexcept{
-    delete []array;
+    std::free(array);
 }
 
 void Bitset::eqs(const Bitset& u, int s) noexcept{


### PR DESCRIPTION
## Summary
- include `<cstdlib>` in `bitset.cpp`
- use `std::free` to release memory allocated with `aligned_alloc`

## Testing
- `g++ -c utils/bitset.cpp -std=c++17`

------
https://chatgpt.com/codex/tasks/task_e_6874013710d48329b56a9ad9ea6bd9e9