### PR TITLE
Remove unused print_model declaration

### DIFF
--- a/light.hpp
+++ b/light.hpp
@@ -74,7 +74,6 @@ public:
 	void share();
 	int solve();
 	void terminate_workers();
-	void print_model();
 };
 
 #endif


### PR DESCRIPTION
## Summary
- удалил неиспользуемое объявление `print_model()` из `light.hpp`
- проверил, что по коду нет вызовов метода `light::print_model`