### PR TITLE
Fix profiling aggregation path in benchmark script

### DIFF
--- a/benchmark_solver.sh
+++ b/benchmark_solver.sh
@@ -10,6 +10,15 @@ fi
 SOLVER="$1"
 CNF_FOLDER="$2"
 
+# Каталог для сохранения итоговых отчётов
+BENCH_DIR="benchmarks"
+mkdir -p "$BENCH_DIR"
+
+# Префикс для файлов профилирования
+PROFILE_PREFIX="$BENCH_DIR/gmon"
+# Очищаем старые данные профилирования
+rm -f "$PROFILE_PREFIX".[0-9]* "$BENCH_DIR"/gmon.sum
+
 total_time=0
 count=0
 
@@ -18,7 +27,7 @@ for cnf_file in "$CNF_FOLDER"/*.cnf; do
     echo " [*] Solving: $cnf_file"
     start=$(date +%s.%N)
 
-    "$SOLVER" "$cnf_file" --nThreads="$N_THREADS" > /dev/null
+    GMON_OUT_PREFIX="$PROFILE_PREFIX" "$SOLVER" "$cnf_file" --nThreads="$N_THREADS" > /dev/null
 
     end=$(date +%s.%N)
 
@@ -33,6 +42,19 @@ for cnf_file in "$CNF_FOLDER"/*.cnf; do
     total_time=$(awk "BEGIN {print $total_time + $elapsed}")
     echo " [+] Elapsed $elapsed sec"
     count=$((count + 1))
+
+    # Объединяем профили текущего запуска
+    for gmon_file in "$PROFILE_PREFIX".*; do
+      [ -f "$gmon_file" ] || continue
+      if [ -f "$BENCH_DIR/gmon.sum" ]; then
+        gprof -s "$SOLVER" "$BENCH_DIR/gmon.sum" "$gmon_file"
+      else
+        gprof -s "$SOLVER" "$gmon_file"
+      fi
+      mv gmon.sum "$BENCH_DIR/gmon.sum"
+      rm -f "$gmon_file"
+    done
+
   fi
 done
 
@@ -43,3 +65,19 @@ fi
 
 average=$(awk "BEGIN {print $total_time / $count}")
 printf "\n Average solving time for %d CNFs: %.3f seconds\n" "$count" "$average"
+
+report_file="$BENCH_DIR/benchmark_$(date +%Y%m%d_%H%M%S).txt"
+
+# Формируем итоговый отчёт
+if [ -f "$BENCH_DIR/gmon.sum" ]; then
+  {
+    printf "Average solving time for %d CNFs: %.3f seconds\n\n" "$count" "$average"
+    echo "Top 5 functions:"
+    gprof "$SOLVER" "$BENCH_DIR/gmon.sum" | \
+      awk 'BEGIN{head=0;count=0} /^Flat profile/ {head=1;print;getline;getline;print;next} head && count<5 {print;count++}'
+  } > "$report_file"
+  echo " [*] Profile saved to $report_file"
+  rm -f "$BENCH_DIR/gmon.sum"
+else
+  echo " [!] gprof data not found"
+fi


### PR DESCRIPTION
## Summary
- refine profiling setup in `benchmark_solver.sh`
- store per-run `gmon` files in `benchmarks` directory
- merge profiling data incrementally after each CNF run
- output top five functions from aggregated profile

## Testing
- `make -j 4` *(fails: boost/thread.hpp missing)*
- `./benchmark_solver.sh ./test ./tmpcnf`


------
https://chatgpt.com/codex/tasks/task_e_6875ff47579c83299754a4156ef33210