### PR TITLE
Optimize kissat propagation

### DIFF
--- a/solvers/kissat-inc/src/proplit.h
+++ b/solvers/kissat-inc/src/proplit.h
@@ -91,34 +91,51 @@ PROPAGATE_LITERAL (kissat * solver,
 
   while (p != end_watches)
     {
-      const watch head = *q++ = *p++;
+      const watch head = *p;
       const unsigned blocking = head.blocking.lit;
       assert (VALID_INTERNAL_LITERAL (blocking));
       const value blocking_value = values[blocking];
       if (head.type.binary)
-	{
-	  if (blocking_value > 0)
-	    continue;
-	  const bool redundant = head.binary.redundant;
-	  if (blocking_value < 0)
-	    {
-	      res = kissat_binary_conflict (solver, redundant,
-					    not_lit, blocking);
-	      break;
-	    }
-	  else
-	    {
-	      assert (!blocking_value);
-	      kissat_assign_binary (solver, values, assigned,
-				    redundant, blocking, not_lit);
-	    }
-	}
+        {
+          p++;
+          if (blocking_value > 0)
+            {
+              if (q != p - 1)
+                *q = head;
+              q++;
+              continue;
+            }
+          const bool redundant = head.binary.redundant;
+          if (blocking_value < 0)
+            {
+              res = kissat_binary_conflict (solver, redundant,
+                                            not_lit, blocking);
+              break;
+            }
+          else
+            {
+              assert (!blocking_value);
+              kissat_assign_binary (solver, values, assigned,
+                                    redundant, blocking, not_lit);
+              if (q != p - 1)
+                q[-1] = head;
+            }
+        }
       else
-	{
-	  const watch tail = *q++ = *p++;
-	  if (blocking_value > 0)
-	    continue;
-	  const reference ref = tail.raw;
+        {
+          const watch tail = p[1];
+          p += 2;
+          if (blocking_value > 0)
+            {
+              if (q != p - 2)
+                {
+                  q[0] = head;
+                  q[1] = tail;
+                }
+              q += 2;
+              continue;
+            }
+          const reference ref = tail.raw;
 	  assert (ref < SIZE_STACK (solver->arena));
 	  clause *c = (clause *) (arena + ref);
 #if defined(HYPER_PROPAGATION) || defined(PROBING_PROPAGATION)


### PR DESCRIPTION
## Summary
- optimize the watch loop in `search_propagate_literal`
- benchmark with gprof

## Testing
- `make clean && make -j`
- `./PRS test.cnf --cutoff=3 --nThreads=1 --preprocessor=0`