### PR TITLE
Add compile-time NLOG to disable logging

### DIFF
--- a/solvers/kissat-inc/src/application.c
+++ b/solvers/kissat-inc/src/application.c
@@ -437,7 +437,7 @@ parse_options (application * application, int argc, char **argv)
 	  application->strict = PEDANTIC_PARSING;
 	  strict_option = arg;
 	}
-#if defined(LOGGING) && !defined(QUIET) && !defined(NOPTIONS)
+#if defined(LOGGING) && !defined(QUIET) && !defined(NOPTIONS) && !defined(NLOG)
       else if (!strcmp (arg, "-l"))
 	{
 	  int value = GET_OPTION (log);

--- a/solvers/kissat-inc/src/inline.h
+++ b/solvers/kissat-inc/src/inline.h
@@ -298,7 +298,10 @@ kissat_checking (kissat * solver)
 static inline bool
 kissat_logging (kissat * solver)
 {
-#ifdef LOGGING
+#ifdef NLOG
+  (void) solver;
+  return false;
+#elif defined(LOGGING)
 #ifdef NOPTIONS
   (void) solver;
 #endif

--- a/solvers/kissat-inc/src/logging.c
+++ b/solvers/kissat-inc/src/logging.c
@@ -1,4 +1,4 @@
-#if defined(LOGGING) && !defined(QUIET)
+#if defined(LOGGING) && !defined(QUIET) && !defined(NLOG)
 
 #include "colors.h"
 #include "inline.h"

--- a/solvers/kissat-inc/src/logging.h
+++ b/solvers/kissat-inc/src/logging.h
@@ -1,7 +1,7 @@
 #ifndef _logging_h_INCLUDED
 #define _logging_h_INCLUDED
 
-#if defined(LOGGING) && !defined(QUIET)
+#if defined(LOGGING) && !defined(QUIET) && !defined(NLOG)
 
 #include "extend.h"
 #include "reference.h"

--- a/solvers/kissat-inc/src/options.h
+++ b/solvers/kissat-inc/src/options.h
@@ -4,6 +4,10 @@
 #include <assert.h>
 #include <stdbool.h>
 
+#ifdef NOPTIONS
+#define NLOG
+#endif
+
 #define OPTIONS \
 OPTION( ands, 1, 0, 1, "extract and eliminate and gates") \
 OPTION( autarky, 1, 0, 1, "delay autarky reasoning") \

--- a/solvers/kissat-inc/src/print.c
+++ b/solvers/kissat-inc/src/print.c
@@ -14,7 +14,7 @@ verbosity (kissat * solver)
 {
   if (!solver)
     return -1;
-#ifdef LOGGING
+#if defined(LOGGING) && !defined(NLOG)
   if (GET_OPTION (log))
     return 2;
 #endif

--- a/solvers/kissat-inc/src/vivify.c
+++ b/solvers/kissat-inc/src/vivify.c
@@ -707,7 +707,7 @@ vivify_clause (kissat * solver, clause * c,
 
   vivify_sort_stack_by_counts (solver, sorted, counts);
 
-#if defined(LOGGING) && !defined(NOPTIONS)
+#if defined(LOGGING) && !defined(NOPTIONS) && !defined(NLOG)
   if (solver->options.log)
     {
       TERMINAL (stdout, 1);


### PR DESCRIPTION
## Summary
- add `NLOG` in `options.h` when `NOPTIONS` forces log to zero
- skip logging code in `logging.h` and related files when `NLOG` is defined
- prevent runtime checks for the logging option