### PR TITLE
Optimize CHB bumping

### DIFF
--- a/solvers/kissat-inc/src/backtrack.c
+++ b/solvers/kissat-inc/src/backtrack.c
@@ -143,6 +143,8 @@ kissat_backtrack (kissat * solver, unsigned new_level)
     }
   RESIZE_STACK (solver->trail, j);
 
+  solver->chb_index = SIZE_STACK (solver->trail);
+
   solver->level = new_level;
   LOG ("unassigned %u literals", unassigned);
   LOG ("reassigned %u literals", reassigned);

--- a/solvers/kissat-inc/src/frames.c
+++ b/solvers/kissat-inc/src/frames.c
@@ -11,5 +11,6 @@ kissat_push_frame (kissat * solver, unsigned decision)
   frame.trail = trail;
   frame.promote = false;
   frame.used = 0;
+  solver->chb_index = trail;
   PUSH_STACK (solver->frames, frame);
 }

--- a/solvers/kissat-inc/src/internal.h
+++ b/solvers/kissat-inc/src/internal.h
@@ -160,6 +160,7 @@ struct kissat
 
   unsigneds trail;
   unsigned propagated;
+  unsigned chb_index;
 
   unsigned best_assigned;
   unsigned consistently_assigned;

--- a/solvers/kissat-inc/src/propsearch.c
+++ b/solvers/kissat-inc/src/propsearch.c
@@ -90,15 +90,20 @@ kissat_search_propagate (kissat * solver)
   STOP (propagate);
 
   // CHB
-  if(solver->stable && solver->heuristic==1){
-      int i = SIZE_STACK (solver->trail) - 1;
-      unsigned lit = i>=0?PEEK_STACK (solver->trail, i):0;  
-      while(i>=0 && LEVEL(lit)==solver->level){
-	    lit = PEEK_STACK (solver->trail, i);
-            kissat_bump_chb(solver,IDX(lit), conflict? 1.0 : 0.9); 
-	    i--;	    
-      }
-  }  
+  if (solver->stable && solver->heuristic == 1)
+    {
+      int end = SIZE_STACK (solver->trail);
+      int i = end - 1;
+      while (i >= 0 && i >= (int) solver->chb_index)
+        {
+          unsigned lit = PEEK_STACK (solver->trail, i);
+          if (LEVEL (lit) != solver->level)
+            break;
+          kissat_bump_chb (solver, IDX (lit), conflict ? 1.0 : 0.9);
+          i--;
+        }
+      solver->chb_index = end;
+    }
   if(solver->stable && solver->heuristic==1 && conflict) kissat_decay_chb(solver);
 
   return conflict;


### PR DESCRIPTION
## Summary
- track trail position for CHB heuristic
- update it on frame push and backtrack
- limit CHB bump loop to new assignments only

## Testing
- `./build.sh` *(fails: boost/thread.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6878a82fcfcc8329944400565a40684e