### PR TITLE
Add restrict qualifier in hot pointer declarations

### DIFF
--- a/solvers/kissat-inc/src/ands.c
+++ b/solvers/kissat-inc/src/ands.c
@@ -22,7 +22,7 @@ kissat_find_and_gate (kissat * solver, unsigned lit, unsigned negative)
 
   const word *arena = BEGIN_STACK (solver->arena);
   value *marks = solver->marks;
-  const value *values = solver->values;
+  const value *__restrict values = solver->values;
 
   clause *base = 0;
   for (all_binary_large_watches (watch, *not_watches))

--- a/solvers/kissat-inc/src/assign.c
+++ b/solvers/kissat-inc/src/assign.c
@@ -15,8 +15,8 @@ kissat_assign (kissat * solver,
   assert (binary || !redundant);
   const unsigned not_lit = NOT (lit);
 #ifndef INLINE_ASSIGN
-  value *values = solver->values;
-  assigned *assigned = solver->assigned;
+  value *__restrict values = solver->values;
+  assigned *__restrict assigned = solver->assigned;
 #endif
   assert (!values[lit]);
   assert (!values[not_lit]);
@@ -122,7 +122,7 @@ kissat_assign_binary (kissat * solver,
 {
   assert (VALUE (other) < 0);
 #ifndef INLINE_ASSIGN
-  assigned *assigned = solver->assigned;
+  assigned *__restrict assigned = solver->assigned;
 #endif
   const unsigned other_idx = IDX (other);
   struct assigned *a = assigned + other_idx;
@@ -149,8 +149,8 @@ kissat_assign_reference (kissat * solver,
 {
   assert (reason == kissat_dereference_clause (solver, ref));
 #ifndef INLINE_ASSIGN
-  assigned *assigned = solver->assigned;
-  value *values = solver->values;
+  assigned *__restrict assigned = solver->assigned;
+  value *__restrict values = solver->values;
 #endif
   const unsigned level =
     kissat_assignment_level (solver, values, assigned, lit, reason);

--- a/solvers/kissat-inc/src/backtrack.c
+++ b/solvers/kissat-inc/src/backtrack.c
@@ -87,9 +87,9 @@ kissat_backtrack (kissat * solver, unsigned new_level)
   const unsigned new_size = new_frame->trail;
   SET_END_OF_STACK (solver->frames, new_frame);
 
-  value *values = solver->values;
+  value *__restrict values = solver->values;
   unsigned *trail = BEGIN_STACK (solver->trail);
-  assigned *assigned = solver->assigned;
+  assigned *__restrict assigned = solver->assigned;
 
   const unsigned old_size = SIZE_STACK (solver->trail);
   unsigned unassigned = 0, reassigned = 0;

--- a/solvers/kissat-inc/src/collect.c
+++ b/solvers/kissat-inc/src/collect.c
@@ -18,8 +18,8 @@ flush_watched_clauses_by_literal (kissat * solver, litpairs * hyper,
 {
   assert (start != INVALID_REF);
 
-  const value *values = solver->values;
-  const assigned *all_assigned = solver->assigned;
+  const value *__restrict values = solver->values;
+  const assigned *__restrict all_assigned = solver->assigned;
 
   const value lit_value = values[lit];
   const assigned *lit_assigned = all_assigned + IDX (lit);
@@ -295,8 +295,8 @@ move_redundant_clauses_to_the_end (kissat * solver, reference ref)
 
   clause *p = begin, *q = begin, *r = redundant;
 
-  const value *values = solver->values;
-  assigned *assigned = solver->assigned;
+  const value *__restrict values = solver->values;
+  assigned *__restrict assigned = solver->assigned;
 
   clause *last_irredundant = kissat_last_irredundant_clause (solver);  
   while (p != end)
@@ -355,8 +355,8 @@ sparse_sweep_garbage_clauses (kissat * solver, bool compact, reference start)
   assert (EMPTY_STACK (solver->added));
   assert (EMPTY_STACK (solver->removed));
 
-  const value *values = solver->values;
-  assigned *assigned = solver->assigned;
+  const value *__restrict values = solver->values;
+  assigned *__restrict assigned = solver->assigned;
 
   size_t flushed_garbage_clauses = 0;
   size_t flushed_satisfied_clauses = 0;
@@ -665,8 +665,8 @@ rewatch_clauses (kissat * solver, reference start)
   LOG ("rewatching clause[%zu] and following clauses", start);
   assert (solver->watching);
 
-  const value *values = solver->values;
-  const assigned *assigned = solver->assigned;
+  const value *__restrict values = solver->values;
+  const assigned *__restrict assigned = solver->assigned;
   watches *watches = solver->watches;
   const word *arena = BEGIN_STACK (solver->arena);
 

--- a/solvers/kissat-inc/src/dense.c
+++ b/solvers/kissat-inc/src/dense.c
@@ -25,7 +25,7 @@ flush_large_watches (kissat * solver,
   else
     LOG ("keep watching redundant binary clauses");
 #endif
-  const value *values = solver->values;
+  const value *__restrict values = solver->values;
   size_t flushed = 0, collected = 0;
   watches *all_watches = solver->watches;
   for (all_literals (lit))
@@ -221,8 +221,8 @@ resume_watching_large_clauses_after_elimination (kissat * solver)
 #endif
   const flags *flags = solver->flags;
   watches *watches = solver->watches;
-  const value *values = solver->values;
-  const assigned *assigned = solver->assigned;
+  const value *__restrict values = solver->values;
+  const assigned *__restrict assigned = solver->assigned;
   const word *arena = BEGIN_STACK (solver->arena);
 
   for (all_clauses (c))

--- a/solvers/kissat-inc/src/failed.c
+++ b/solvers/kissat-inc/src/failed.c
@@ -36,7 +36,7 @@ schedule_probes (kissat * solver, unsigned round, unsigneds * roots)
   assert (EMPTY_STACK (*roots));
   LOG ("collecting roots of binary implication graph");
   assert (solver->watching);
-  const value *values = solver->values;
+  const value *__restrict values = solver->values;
   value *marks = solver->marks;
   flags *flags = solver->flags;
   for (all_variables (idx))
@@ -220,7 +220,7 @@ probe_round (kissat * solver, unsigned round,
   const unsigned scheduled = SIZE_STACK (*probes);
 #endif
   unsigned *stamps = kissat_calloc (solver, LITS, sizeof *stamps);
-  const value *values = solver->values;
+  const value *__restrict values = solver->values;
   flags *flags = solver->flags;
 
 #if !defined(NDEBUG) && !defined(NMETRICS)

--- a/solvers/kissat-inc/src/minimize.c
+++ b/solvers/kissat-inc/src/minimize.c
@@ -152,7 +152,7 @@ kissat_minimize_clause (kissat * solver)
 
   unsigned minimized = 0;
 
-  assigned *assigned = solver->assigned;
+  assigned *__restrict assigned = solver->assigned;
 
   for (const unsigned *p = q; p != end; p++)
     {

--- a/solvers/kissat-inc/src/propdense.c
+++ b/solvers/kissat-inc/src/propdense.c
@@ -22,8 +22,8 @@ non_watching_propagate_literal (kissat * solver,
   unsigned ticks = 1 + kissat_cache_lines (watches->size, sizeof (watch));
 
   const word *arena = BEGIN_STACK (solver->arena);
-  assigned *assigned = solver->assigned;
-  value *values = solver->values;
+  assigned *__restrict assigned = solver->assigned;
+  value *__restrict values = solver->values;
 
   const unsigned level = solver->level;
 

--- a/solvers/kissat-inc/src/prophyper.c
+++ b/solvers/kissat-inc/src/prophyper.c
@@ -71,8 +71,8 @@ binary_propagate_literal (kissat * solver, unsigned lit)
   const unsigned not_lit = NOT (lit);
 
   watches *watches = &WATCHES (not_lit);
-  value *values = solver->values;
-  assigned *assigned = solver->assigned;
+  value *__restrict values = solver->values;
+  assigned *__restrict assigned = solver->assigned;
 
   const watch *begin = BEGIN_WATCHES (*watches);
   const watch *end = END_WATCHES (*watches);

--- a/solvers/kissat-inc/src/proplit.h
+++ b/solvers/kissat-inc/src/proplit.h
@@ -73,8 +73,8 @@ PROPAGATE_LITERAL (kissat * solver,
   assert (EMPTY_STACK (solver->delayed));
 
   const word *arena = BEGIN_STACK (solver->arena);
-  assigned *assigned = solver->assigned;
-  value *values = solver->values;
+  assigned *__restrict assigned = solver->assigned;
+  value *__restrict values = solver->values;
 
   const unsigned not_lit = NOT (lit);
 #ifdef HYPER_PROPAGATION

--- a/solvers/kissat-inc/src/resolve.c
+++ b/solvers/kissat-inc/src/resolve.c
@@ -18,7 +18,7 @@ occurrences_literal (kissat * solver, unsigned lit, bool * update)
   watch *begin = BEGIN_WATCHES (*watches), *q = begin;
   const watch *end = END_WATCHES (*watches), *p = q;
 
-  const value *values = solver->values;
+  const value *__restrict values = solver->values;
   const word *arena = BEGIN_STACK (solver->arena);
 
   bool failed = false;
@@ -114,7 +114,7 @@ generate_resolvents (kissat * solver, unsigned lit,
   tmp0.size = tmp1.size = 2;
 
   const word *arena = BEGIN_STACK (solver->arena);
-  const value *values = solver->values;
+  const value *__restrict values = solver->values;
   value *marks = solver->marks;
 
   const unsigned clslim = solver->bounds.eliminate.clause_size;

--- a/solvers/kissat-inc/src/substitute.c
+++ b/solvers/kissat-inc/src/substitute.c
@@ -283,7 +283,7 @@ remove_representative_equivalences (kissat * solver,
 {
   if (!solver->inconsistent)
     {
-      value *values = solver->values;
+      value *__restrict values = solver->values;
       const bool incremental = GET_OPTION (incremental);
       for (all_variables (idx))
 	{
@@ -437,7 +437,7 @@ substitute_clauses (kissat * solver, unsigned *repr)
 {
   if (solver->inconsistent)
     return;
-  const value *values = solver->values;
+  const value *__restrict values = solver->values;
   value *marks = solver->marks;
   size_t substituted = 0;
   size_t removed = 0;

--- a/solvers/kissat-inc/src/transitive.c
+++ b/solvers/kissat-inc/src/transitive.c
@@ -15,7 +15,7 @@ static void
 transitive_assign(kissat *solver, unsigned lit)
 {
   LOG("transitive assign %s", LOGLIT(lit));
-  value *values = solver->values;
+  value *__restrict values = solver->values;
   const unsigned not_lit = NOT(lit);
   assert(!values[lit]);
   assert(!values[not_lit]);
@@ -28,7 +28,7 @@ static void
 transitive_backtrack(kissat *solver, unsigned saved)
 {
   assert(saved <= SIZE_STACK(solver->trail));
-  value *values = solver->values;
+  value *__restrict values = solver->values;
   while (SIZE_STACK(solver->trail) > saved)
   {
     const unsigned lit = POP_STACK(solver->trail);

--- a/solvers/kissat-inc/src/walk.c
+++ b/solvers/kissat-inc/src/walk.c
@@ -189,7 +189,7 @@ import_decision_phases (walker * walker)
   const value initial_phase = INITIAL_PHASE;
   const flags *flags = solver->flags;
   const bool stable = solver->stable;
-  value *values = solver->values;
+  value *__restrict values = solver->values;
   for (all_variables (idx))
     {
       if (!flags[idx].active)
@@ -216,7 +216,7 @@ static unsigned
 connect_binary_counters (walker * walker)
 {
   kissat *solver = walker->solver;
-  value *values = solver->values;
+  value *__restrict values = solver->values;
   tagged *refs = walker->refs;
   watches *all_watches = solver->watches;
   counter *counters = walker->counters;
@@ -267,7 +267,7 @@ connect_large_counters (walker * walker, unsigned counter_ref)
   kissat *solver = walker->solver;
   assert (!solver->level);
   const value *saved = walker->saved;
-  const value *values = solver->values;
+  const value *__restrict values = solver->values;
   const word *arena = BEGIN_STACK (solver->arena);
   counter *counters = walker->counters;
   tagged *refs = walker->refs;
@@ -472,7 +472,7 @@ pick_literal (kissat * solver, walker * walker)
 
   assert (EMPTY_STACK (walker->scores));
 
-  value *values = solver->values;
+  value *__restrict values = solver->values;
 
   double sum = 0;
   unsigned picked_lit = INVALID_LIT;
@@ -613,7 +613,7 @@ save_all_values (kissat * solver, walker * walker)
   assert (EMPTY_STACK (walker->trail));
   assert (walker->best == INVALID_BEST);
   LOG ("copying all values as saved phases since trail is invalid");
-  const value *values = solver->values;
+  const value *__restrict values = solver->values;
   phase *phases = solver->phases;
   for (all_variables (idx))
     {
@@ -640,7 +640,7 @@ save_walker_trail (kissat * solver, walker * walker, bool keep)
 #endif
   unsigned *begin = BEGIN_STACK (walker->trail);
   const unsigned *best = begin + walker->best;
-  const value *values = solver->values;
+  const value *__restrict values = solver->values;
   phase *phases = solver->phases;
   for (const unsigned *p = begin; p != best; p++)
     {
@@ -719,7 +719,7 @@ static void
 flip_literal (kissat * solver, walker * walker, unsigned flip)
 {
   LOG ("flipping literal %s", LOGLIT (flip));
-  value *values = solver->values;
+  value *__restrict values = solver->values;
   const value value = values[flip];
   assert (value < 0);
   values[flip] = -value;

--- a/solvers/kissat-inc/src/watch.c
+++ b/solvers/kissat-inc/src/watch.c
@@ -62,8 +62,8 @@ kissat_watch_large_clauses (kissat * solver)
   LOG ("watching all large clauses");
   assert (solver->watching);
 
-  const value *values = solver->values;
-  const assigned *assigned = solver->assigned;
+  const value *__restrict values = solver->values;
+  const assigned *__restrict assigned = solver->assigned;
   watches *watches = solver->watches;
   const word *arena = BEGIN_STACK (solver->arena);
 


### PR DESCRIPTION
## Summary
- optimize pointer aliasing hints in several hot code paths
- add `__restrict` to `assigned` and `values` local pointers in propagation, assignment, and other performance-critical functions